### PR TITLE
Running git-fat under custom isolated envs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,3 +26,11 @@ BUGFIXES
 BUGFIXES
 
 - Fixed issue that prevented files from being found with the find command.
+
+0.2.3
+-----
+
+BUGFIXES
+
+- Fixed issue that can't allow to run system-wide installed ``git-fat`` script
+  under some types of isolated environments.

--- a/git_fat/git_fat.py
+++ b/git_fat/git_fat.py
@@ -37,7 +37,7 @@ except ImportError:
 
     sub.check_output = backport_check_output
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 
 BLOCK_SIZE = 4096
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,51 @@
+import os
+
+from distutils import log
+from distutils.command.build_scripts import build_scripts as _build_scripts
 from distutils.core import setup
+from distutils.util import convert_path
+
 from git_fat import __version__
+
+
+SYS_PATH_PATCH = '''
+### this trick solves issue with running scripts in isolated env ###
+import sys
+git_fat_lib_location = '%s'
+if git_fat_lib_location not in sys.path:
+    # no sense for current $PYTHONPATH configuration - we always knowns
+    # where are sources and can import git_fat
+    sys.path.insert(0, git_fat_lib_location)
+### end of trick ###
+'''
+
+
+class build_scripts(_build_scripts):
+    def run(self):
+        # installing scripts normal way
+        _build_scripts.run(self)
+
+        # making patch with actual target location for git_fat sources
+        install_lib = self.get_finalized_command('install_lib')
+        patch = SYS_PATH_PATCH % install_lib.install_dir
+
+        if not self.dry_run:
+            for script in self.scripts:
+                script = convert_path(script)
+                outfile = os.path.join(self.build_dir, os.path.basename(script))
+                with open(outfile, 'r+') as f:
+                    lines = f.readlines()
+                    for i, l in enumerate(lines):
+                        # placing patch after first shebang or comment
+                        if not l.startswith('#'):
+                            lines[i] = patch + l
+                            break
+                    # rewriting updated script
+                    f.seek(0)
+                    f.truncate()
+                    log.info("patching %s", outfile)
+                    f.writelines(lines)
+
 
 setup(
     name='git-fat',
@@ -8,6 +54,7 @@ setup(
     url='https://github.com/cyaninc/git-fat',
     version=__version__,
     packages=['git_fat'],
+    cmdclass={"build_scripts": build_scripts},
     scripts=['bin/git-fat'],
     license='BSD 2-Clause',
     description="Manage large binary files with git",


### PR DESCRIPTION
## TLDR

This pull requests applying a patch in installation run-time, which provides access to `git_fat` package sources from `git-fat` script anytime with any `$PYTHONPATH`/`$PYTHONHOME` configuration.
## Problem

By default `pip install` places sources of installed packages under `/usr/local/lib/pythonX.X/dist-packages` and scripts under `/usr/local/bin` at Debian-based distros. In some cases for custom envs, which manipulates `$PYTHONPATH`/`$PYTHONHOME` or in mutli-pythonic configurations, sources from dist-packages unavailable and `git-fat` fails with `ImportError`.

Lets follow step-by-step:

```
$ sudo pip install git-fat==0.2.2
$ git-fat
usage: git-fat [global options] command [command options]
       git-fat -h for full usage.
git-fat: error: too few arguments
$ whereis git-fat
git-fat: /usr/local/bin/git-fat
$ python -c 'import git_fat;print(git_fat.__file__)'
/usr/local/lib/python2.7/dist-packages/git_fat/__init__.pyc
```

Works. Now creating a simple env:

```
$ echo "export PYTHONHOME=/opt/cyan/cyms-base-py27
export PYTHONPATH=/opt/cyan/cyms-base-py27/lib/python2.7/site-packages/" > env.sh
$ source env.sh 
$ git-fat
Traceback (most recent call last):
  File "/usr/local/bin/git-fat", line 3, in <module>
    from git_fat import main
ImportError: No module named git_fat
```

Reverting system

```
$ unset PYTHONPATH
$ unset PYTHONHOME
$ sudo pip uninstall -y git-fat
```
## Solution

Installing `git-fat` version with described fix:

```
$ sudo pip install ./git-fat
$ git-fat
usage: git-fat [global options] command [command options]
       git-fat -h for full usage.
git-fat: error: too few arguments
$ source env.sh 
$ git-fat
usage: git-fat [global options] command [command options]
       git-fat -h for full usage.
git-fat: error: too few arguments
```

But env is still isolated as expected:

```
$ python -c 'import git_fat'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named git_fat
$ unset PYTHONHOME
$ unset PYTHONPATH
$ python -c 'import git_fat;print("Ok")'
Ok
```
