### PR TITLE
Coverage working again

### DIFF
--- a/tests/test_git_fat.py
+++ b/tests/test_git_fat.py
@@ -4,6 +4,7 @@ import subprocess as sub
 import tempfile
 import unittest
 import logging
+import time
 
 
 logging.basicConfig(format='%(levelname)s:%(filename)s:%(message)s')
@@ -76,6 +77,9 @@ class Base(unittest.TestCase):
             f.write('*.fat filter=fat -crlf')
 
     def tearDown(self):
+        call('coverage combine')
+        os.rename(os.path.join(self.repo, '.coverage'),
+            os.path.join(self.olddir, '.coverage.{}'.format(time.time())))
         os.chdir(self.olddir)
         shutil.rmtree(self.tempdir)
         os.environ["PATH"] = self.oldpath


### PR DESCRIPTION
Got coverage working again after some pain.  Turns out, coverage combine
will combine anything that matches `.coverage.*` which is convient since
I didn't want to have to generate a random string for the filename
(because I'm lazy).  That's why you'll see time.time() used to rename
the file
