### PR TITLE
better error message when rsync isn't in your path

### DIFF
--- a/git_fat/git_fat.py
+++ b/git_fat/git_fat.py
@@ -284,7 +284,12 @@ class RSyncBackend(BackendInterface):
 
     def pull_files(self, file_list):
         rsync = self._rsync(push=False)
-        p = sub.Popen(rsync, stdin=sub.PIPE)
+        try:
+            p = sub.Popen(rsync, stdin=sub.PIPE)
+        except OSError:
+            ## re-raise with a more useful message
+            raise OSError('Error running "%s"' % " ".join(rsync))
+
         p.communicate(input='\x00'.join(file_list))
         # TODO: fix for success check
         return True


### PR DESCRIPTION
didn't have rsync installed in a container; the vanilla traceback of:

``` python
$ git fat pull
rpath: %r 1
Traceback (most recent call last):
  File "/usr/local/bin/git-fat", line 5, in <module>
    pkg_resources.run_script('git-fat==0.3.1', 'git-fat')
  File "build/bdist.linux-x86_64/egg/pkg_resources.py", line 534, in run_script
  File "build/bdist.linux-x86_64/egg/pkg_resources.py", line 1441, in run_script
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 959, in <module>
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 948, in main
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 860, in run
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 764, in pull
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 291, in pull_files
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1249, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

doesn't really help much.  With this patch we get the much more useful:

``` python
$ git fat pull
Traceback (most recent call last):
  File "/usr/local/bin/git-fat", line 5, in <module>
    pkg_resources.run_script('git-fat==0.3.1', 'git-fat')
  File "build/bdist.linux-x86_64/egg/pkg_resources.py", line 534, in run_script
  File "build/bdist.linux-x86_64/egg/pkg_resources.py", line 1441, in run_script
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 950, in <module>
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 939, in main
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 851, in run
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 755, in pull
  File "/usr/local/lib/python2.7/dist-packages/git_fat-0.3.1-py2.7.egg/EGG-INFO/scripts/git-fat", line 291, in pull_files

OSError: Error running "rsync --progress --ignore-existing --from0 --files-from=- hostname:gitfat/projectname .git/fat/objects/ --rsh=ssh -l git -p 22"
```

Which makes realizing that you don't have rsync installed in your lxc reasonably quick and easy.
