### PR TITLE
Use 'git config' instead of ConfigParser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,10 +81,10 @@ See also other scripts in the win32/ directory:
 
 Configuration
 -------------
-``git-fat`` is configured through ``filter`` attributes in  the  regular
-``gitattributes`` files (see ``git help gitattributes``)  and through
-``git-fat``-specific configuration settings typically  in a ``.gitfat`` file
-at the root of the repository. The details and examples of these can be
+``git-fat`` is configured through ``filter`` attributes in regular
+``.gitattributes`` files (see ``git help gitattributes``)  and through
+git-fat-specific configuration settings, typically  in a ``.gitfat`` file
+at the root of the repository. More details and examples of these can be
 found below.
 
 Note that version 0.4.0 of ``git-fat`` introduces new optional constructs
@@ -141,8 +141,8 @@ in the *main configuration file* (and only there).
     key1 = default-value-1
 
 When placed in the *main configurtion file*, the section above means that if -and only if- a
-setting with *setting name* ``original-section.key`` has not been defined in any configuration
-file, the interpolation of the string ``{original-section.key}`` will yield ``default-value-1``,
+setting with *setting name* ``original-section.key1`` has not been defined in any configuration
+file, the interpolation of the string ``{original-section.key1}`` will yield ``default-value-1``,
 otherwise it will yield the value it was given in the configuration file where it was defined.
 
 Example files
@@ -150,10 +150,10 @@ Example files
 
 ``.gitattributes``
 '''''''''''''''''''
-This file is located at the root of the repository and determines which files
-get converted to ``git-fat`` files. See
+``git-fat`` manages only those files for which the attribute ``filter=fat`` has been specified
+in a ``.gitattributes`` file. See ``git help gitattributes`` or have a look at
 `git attributes <http://git-scm.com/book/en/Customizing-Git-Git-Attributes>`_
-for further information.
+for general information on the ``.gitattributes`` files.
 
 ::
 
@@ -162,6 +162,9 @@ for further information.
     *.gz filter=fat -crlf
     *.zip filter=fat -crlf
     EOF
+
+If placed at the root of the repository, the file above would instruct ``git-fat``
+to handle all ``*.deb``, ``*.gz`` and ``*.zip`` files inside the repository.
 
 ``.gitfat`` (legacy)
 ''''''''''''''''''''''''
@@ -287,7 +290,7 @@ they try to pull fat-files.
 
 After we've done a new clone of a repository using ``git-fat``, to get
 the additional files we do a fat pull.  This will pull the default backend
-which can be explicitely mentioned as in the namespaced ``.gitfat`` example
+which can be explicitly mentioned as in the namespaced ``.gitfat`` example
 above, or else is determined by the first entry in the *main configuration
 file*, as in the legacy ``.gitfat`` example above.
 

--- a/README.rst
+++ b/README.rst
@@ -79,26 +79,94 @@ See also other scripts in the win32/ directory:
 -  setup_wheel.bat - create a binary Python Wheel package in the dist/
    directory and install that package
 
-Usage
------
+Configuration
+-------------
+``git-fat`` is configured by defining in the ``.gitattributes``
+file at the root the repository which files it should manage and by
+providing git-fat-specific configuration settings, typically  in a
+``.gitfat`` file also at the root of the repository.
 
-First, create a
+Note that version 0.4.0 of ``git-fat`` introduces new optional constructs
+in the configuration domain without sacrificing support for the configuration
+syntax used in previous versions (called legacy configuration files
+below).
+
+Modes of operation
+~~~~~~~~~~~~~~~~~~
+
+When it comes to the git-fat-specific configuration settings, there is
+two modes of operation.
+
+Implicit configuration (default)
+''''''''''''''''''''''''''''''''
+
+When no configuration files are passed as arguments to the ``-c`` option,
+``git-fat`` parses the following configuration files in the order they
+are listed here:
+
+1. If ``$GIT_FAT_CONFIG`` is defined and contains a colon-separated list of files,
+   ``git-fat`` parses those files, overriding previously defined settings with the
+   same name if they exist.
+2. The regular Git configuration files (see the ``FILES`` section of  ``man git-config``)
+   are parsed, overriding any previously defined configuration settings with the same name
+   if they exist.
+3. The ``.gitfat`` configuration file at the root of the repository is parsed,
+   overriding previously defined configuration settings with the same name if they exist.
+   In this case the ``.gitfat`` file is considered to be the *main configuration file*.
+
+Explicit configuration
+''''''''''''''''''''''
+
+When one or more configuration files are passed as arguments to the ``-c`` option,
+``git-fat`` processes each of those files in the order they were passed,
+overriding previously defined configuration settings with the same name if they exist.
+
+In this case, the last one of the files is considered to be the *main configuration file*.
+
+Interpolation
+~~~~~~~~~~~~~
+
+``git-fat`` performs interpolation on the setting values that are used by ``git-fat`` itself.
+Interpolation consists on replacing *setting names* delimited by curly braces {} with the value
+of those settings. *Setting names* are dot-separated strings with the section, subsection (if
+applicable) and key names of settings defined in the parsed configuration files.
+
+For the sake of integrity, it is possible to specify default values for interpolation
+in the *main configuration file* (and only there).
+
+::
+
+    [defaults "original-section"]
+    key1 = default-value-1
+
+When placed in the *main configurtion file*, the section above means that if -and only if- a
+setting with *setting name* ``original-section.key`` has not been defined in any configuration
+file, the interpolation of the string ``{original-section.key}`` will yield ``default-value-1``,
+otherwise it will yield the value it was given in the configuration file where it was defined.
+
+Example files
+~~~~~~~~~~~~~~
+
+``.gitattributes``
+'''''''''''''''''''
+This file is located at the root of the repository and determines which files
+get converted to ``git-fat`` files. See
 `git attributes <http://git-scm.com/book/en/Customizing-Git-Git-Attributes>`_
-file in the root of your repository. This file determines which files
-get converted to ``git-fat`` files.
+for further information.
 
 ::
 
     cat >> .gitattributes <<EOF
-    *.deb filter=fat -crlf
+    *.deb filter=kat -crlf
     *.gz filter=fat -crlf
     *.zip filter=fat -crlf
     EOF
 
-Next, create a ``.gitfat`` configuration file in the root of your repo
-that contains the location of the remote store for the binary files.
-Optionally include the ssh user and port if non-standard. Also,
-optionally include an http remote for anonymous clones.
+``.gitfat`` (legacy)
+''''''''''''''''''''''''
+
+``.gitfat`` is typically located at root of the repository but could be
+explicitly passed as argument to the ``-c`` options (see *Modes of operation* above).
 
 ::
 
@@ -109,11 +177,98 @@ optionally include an http remote for anonymous clones.
     [http]
     remote = http://storage.example.com/store
 
-Commit those files so that others will be able to use them.
+In this case the first section of the file is treated as the default backend.
 
-Initialize the repository. This adds a line to ``.git/config`` telling
-git what command to run for the ``fat`` filter is in the
-``.gitattributes`` file.
+For legacy ``.gitfat`` files indentation is discouraged as it is not supported by
+previous versions of ``git-fat``.
+
+``.gitfat`` (namespaced)
+''''''''''''''''''''''''''''''''''''''
+
+::
+
+	[gitfat]
+		backend = rsync
+		canned-error-message = "A message to append on stderr on run-time errors"
+	[gitfat "rsync"]
+		remote = storage.example.com:/path/to/store
+		user = git
+		port = 2222
+	[gitfat "http"]
+		remote = http://storage.example.com/store
+
+In this case the default backend is explicitly mentioned.
+
+Note that indentation is possible, but it must be done with tabs.
+
+This syntax is not compatible with ``git-fat`` versions prior to 0.4.0.
+
+``.gitfat`` (interpolated)
+''''''''''''''''''''''''''''
+This example meant to be used in combination with *supporting
+configuration files* (see below) and makes uses of the interpolation
+mechanism described above.
+
+::
+
+	[gitfat]
+		canned-error-message = "A message to append on stderr on run-time errors"
+	[gitfat "rsync"]
+		remote = {siteconfig.synchost}:{siteconfig.syncroot}
+		user = git
+		port = 2222
+	[gitfat "http"]
+		remote = {siteconfig.http-url}
+	[defaults "gitfat"]
+		backend = rsync
+	[defaults "siteconfig"]
+		synchost = localhost
+		syncroot = /path/to/local/store/mount
+		http-url = http://storage.example.com/store
+
+Note that indentation is possible, but it must be done with tabs.
+
+This syntax is not compatible with ``git-fat`` versions prior to 0.4.0.
+
+*Supporting configuration file*
+'''''''''''''''''''''''''''''''
+*Supporting configuration files* are typically used to define settings that require
+site, repository or user variability.
+
+Examples of supporting configuration files are:
+
+* An arbitrary file path contained in ``$GIT_FAT_CONFIG``.
+* ``~/.gitconfig`` for user-specific settings.
+* ``.git/config`` at the root of a repository for local, repository-wide settings.
+* An arbitrary file path passed to ``git-fat`` as an argument to ``-c`` option not
+  being the last ``-c`` option in the invocation call.
+
+A configuration file thought to complement the interpolated ``.git-fat`` file above
+may look like the following:
+
+::
+
+	[gitfat]
+		backend = rsync
+	[siteconfig]
+		synchost = storage.example.com
+		syncroot = /path/to/store
+		http-url = http://storage.example.com/store
+
+This syntax is not compatible with ``git-fat`` versions prior to 0.4.0.
+
+Usage
+-----
+
+The commands described below require that the ``.gitattributes`` and
+the configuration files (typically just ``.gitfat``) have been set up
+as described in the *Configuration* section above.  Remember to commit
+the ``.gitfat`` and ``.gitattributes`` files so that others will be
+able to use them.
+
+The command below is used to initialize the repository. This adds a line to
+``.git/config`` telling git what command to run for the ``fat`` filter referred to in
+the ``.gitattributes`` file.
 
 ::
 
@@ -131,7 +286,9 @@ they try to pull fat-files.
 
 After we've done a new clone of a repository using ``git-fat``, to get
 the additional files we do a fat pull.  This will pull the default backend
-as determined by the first entry in the ``.gitfat`` file for the repo.
+which can be explicitely mentioned as in the namespaced ``.gitfat`` example
+above, or else is determined by the first entry in the *main configuration
+file*, as in the legacy ``.gitfat`` example above.
 
 ::
 
@@ -303,7 +460,6 @@ Improvements
 
 -  Better Documentation (esp. setting up a server)
 -  Improved Testing
--  config file location argument (global)
 -  cli option to specify which backend to use for push and pull (http, rsync, etc)
 -  Python 3 compatibility (without six)
 -  Really implement pattern matching

--- a/README.rst
+++ b/README.rst
@@ -81,10 +81,11 @@ See also other scripts in the win32/ directory:
 
 Configuration
 -------------
-``git-fat`` is configured by defining in the ``.gitattributes``
-file at the root the repository which files it should manage and by
-providing git-fat-specific configuration settings, typically  in a
-``.gitfat`` file also at the root of the repository.
+``git-fat`` is configured through ``filter`` attributes in  the  regular
+``gitattributes`` files (see ``git help gitattributes``)  and through
+``git-fat``-specific configuration settings typically  in a ``.gitfat`` file
+at the root of the repository. The details and examples of these can be
+found below.
 
 Note that version 0.4.0 of ``git-fat`` introduces new optional constructs
 in the configuration domain without sacrificing support for the configuration
@@ -157,7 +158,7 @@ for further information.
 ::
 
     cat >> .gitattributes <<EOF
-    *.deb filter=kat -crlf
+    *.deb filter=fat -crlf
     *.gz filter=fat -crlf
     *.zip filter=fat -crlf
     EOF

--- a/git_fat/git_fat.py
+++ b/git_fat/git_fat.py
@@ -48,7 +48,7 @@ except ImportError:
 
     sub.check_output = backport_check_output
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 BLOCK_SIZE = 4096
 

--- a/git_fat/git_fat.py
+++ b/git_fat/git_fat.py
@@ -9,12 +9,13 @@ import subprocess as sub
 import sys
 import tempfile
 import warnings
-import ConfigParser as cfgparser
 import logging as _logging  # Use logger.error(), not logging.error()
 import shutil
 import argparse
 import platform
 import stat
+import string
+import re
 
 _logging.basicConfig(format='%(levelname)s:%(filename)s: %(message)s')
 logger = _logging.getLogger(__name__)
@@ -47,7 +48,7 @@ except ImportError:
 
     sub.check_output = backport_check_output
 
-__version__ = '0.3.4'
+__version__ = '0.4.0'
 
 BLOCK_SIZE = 4096
 
@@ -182,27 +183,6 @@ def cat_iter(initer, outstream):
 
 def cat(instream, outstream):
     return cat_iter(readblocks(instream), outstream)
-
-
-def gitconfig_get(name, cfgfile=None):
-    args = ['config', '--get']
-    if cfgfile is not None:
-        args += ['--file', cfgfile]
-    args.append(name)
-    p = git(args, stdout=sub.PIPE)
-    output = p.communicate()[0].strip()
-    if p.returncode != 0:
-        return ''
-    else:
-        return output
-
-
-def gitconfig_set(name, value, cfgfile=None):
-    args = ['git', 'config']
-    if cfgfile is not None:
-        args += ['--file', cfgfile]
-    args += [name, value]
-    sub.check_call(args)
 
 
 def _config_path(path=None):
@@ -425,16 +405,14 @@ class RSyncBackend(BackendInterface):
             raise OSError('Error running "%s"' % " ".join(rsync))
 
         p.communicate(input='\x00'.join(file_list))
-        # TODO: fix for success check
-        return True
+        return p.returncode == 0
 
     def push_files(self, file_list):
         rsync = self._rsync(push=True)
         logger.debug("rsync push command: {}".format(" ".join(rsync)))
         p = sub.Popen(rsync, stdin=sub.PIPE)
         p.communicate(input='\x00'.join(file_list))
-        # TODO: fix for success check
-        return True
+        return p.returncode == 0
 
 
 BACKEND_MAP = {
@@ -446,10 +424,11 @@ BACKEND_MAP = {
 
 class GitFat(object):
 
-    def __init__(self, backend, full_history=False):
+    def __init__(self, backend, config, full_history=False):
 
         # The backend instance we use to get the files
         self.backend = backend
+        self.config = config
         self.full_history = full_history
         self.rev = None  # Unused
         self.objdir = _obj_dir()
@@ -472,8 +451,8 @@ class GitFat(object):
         '''
         if not self._configured():
             print('Setting filters in .git/config')
-            gitconfig_set('filter.fat.clean', 'git-fat filter-clean %f')
-            gitconfig_set('filter.fat.smudge', 'git-fat filter-smudge %f')
+            self.config.set('filter.fat.clean', 'git-fat filter-clean %f', update_gitconfig = True)
+            self.config.set('filter.fat.smudge', 'git-fat filter-smudge %f', update_gitconfig = True)
             print('Creating .git/fat/objects')
             mkdir_p(self.objdir)
             print('Initialized git-fat')
@@ -483,7 +462,7 @@ class GitFat(object):
         Returns true if git-fat is already configured
         '''
         reqs = os.path.isdir(self.objdir)
-        filters = gitconfig_get('filter.fat.clean') and gitconfig_get('filter.fat.smudge')
+        filters = self.config.get('filter.fat.clean') and self.config.get('filter.fat.smudge')
         return filters and reqs
 
     def _encode(self, digest, size):
@@ -926,7 +905,7 @@ class GitFat(object):
                      .format(patterns, kwargs, len(files)))
 
         if not self.backend.pull_files(files):
-            sys.exit(1)
+            raise RuntimeError("Pull operation terminated abnormally")
         # Make sure they're up to date
         if kwargs.pop("many_binaries", False):
             print('in accelerating mode')
@@ -942,7 +921,7 @@ class GitFat(object):
         logger.debug("PUSH: unused_pattern={}, kwargs={}, len(files)={}"
                      .format(unused_pattern, kwargs, len(files)))
         if not self.backend.push_files(files):
-            sys.exit(1)
+            raise RuntimeError("Push operation terminated abnormally")
 
     def _status(self, **kwargs):
         '''
@@ -968,45 +947,20 @@ class GitFat(object):
             for g in stale:
                 print('\t' + g)
 
-
-def _get_options(config, backend, cfg_file_path):
-    """ returns the options for a backend in dictionary form """
-    try:
-        opts = dict(config.items(backend))
-    except cfgparser.NoSectionError:
-        err = "No section found in {} for backend {}".format(cfg_file_path, backend)
-        raise RuntimeError(err)
-    return opts
-
-
-def _read_config(cfg_file_path=None):
-    config = cfgparser.SafeConfigParser()
-    if not os.path.exists(cfg_file_path):
-        # Can't continue, but this isn't unusual
-        logger.warning("This does not appear to be a repository managed by git-fat. "
-                       "Missing configfile at: {}".format(cfg_file_path))
-        sys.exit(0)
-    try:
-        config.read(cfg_file_path)
-    except cfgparser.Error:  # TODO: figure out what to catch here
-        raise RuntimeError("Error reading or parsing configfile: {}".format(cfg_file_path))
-    return config
-
-
-def _parse_config(backend=None, cfg_file_path=None):
-    """ Parse the given config file and return the backend instance """
-    cfg_file_path = _config_path(path=cfg_file_path)
-    config = _read_config(cfg_file_path)
+def _get_backend(config, backend=None):
+    """Return the backend instance """
     if backend is None:
-        try:
-            backends = config.sections()
-        except cfgparser.Error:
-            raise RuntimeError("Error reading or parsing configfile: {}".format(cfg_file_path))
-        if not backends:  # e.g. empty file
-            raise RuntimeError("No backends configured in config: {}".format(cfg_file_path))
-        backend = backends[0]
-
-    opts = _get_options(config, backend, cfg_file_path)
+        backend = config.get('gitfat.backend') or config.get('gitfat.runtime.firstsection')
+        if backend is None:
+            if config.get('gitfat.runtime.parsed-git-config') and len(config.get('gitfat.runtime.parsed-files')) == 1:
+                #To keep the original behaviour, just exit with status code when no .gitfat file was parsed
+                logger.warning("This does not appear to be a repository managed by git-fat. ")
+                sys.exit(0)
+            else:
+                raise RuntimeError("No backends configured in  {}".format(config.get('gitfat.runtime.parsed-files')[-1]))
+    opts = config.get('gitfat.'+backend) or config.get(backend)
+    if opts is None:
+        raise RuntimeError("Could not find section gitfat.{} or {} in configuration data from {}".format(backend, backend, config.get('gitfat.runtime.parsed-files')))
     base_dir = _obj_dir()
 
     try:
@@ -1016,11 +970,11 @@ def _parse_config(backend=None, cfg_file_path=None):
     return Backend(base_dir, **opts)
 
 
-def run(backend, **kwargs):
+def run(backend, config, **kwargs):
     make_sys_streams_binary()
     name = kwargs.pop('func')
     full_history = kwargs.pop('full_history')
-    gitfat = GitFat(backend, full_history=full_history)
+    gitfat = GitFat(backend, config, full_history=full_history)
     fn = name.replace("-", "_")
     if not hasattr(gitfat, fn):
         raise Exception("Unknown function called")
@@ -1039,11 +993,163 @@ def _configure_logging(log_level):
         logger.addHandler(file_handler)
     logger.setLevel(log_level)
 
+class ConfigFormatter(string.Formatter):
+    """Allows object notation when interpolating against the config dict"""
+    def get_field(self, field_name, args, kwargs):
+        """Allows object notation against dict, and keeps track of visited keys"""
+        if field_name in self._visited_keys:
+            raise RuntimeError("Circular reference detected, where the following keys are involved: {}".format(self._visited_keys))
+        else:
+            self._visited_keys.append(field_name)
+        fields = field_name.split('.')
+        obj = self.get_value(fields[0], args, kwargs)
+        for field in fields[1:]:
+            obj = obj[field]
+        return obj, fields[0]
+    def vformat(self, format_string, visited_keys, args, kwargs):
+        """Just a wrapper to the standard vformat with an extra param for keeping track of circular refrences"""
+        self._visited_keys = visited_keys
+        return super(ConfigFormatter, self).vformat(format_string, args, kwargs)
 
-def _load_backend(kwargs):
+class GitFatConfig(object):
+    """Configuration cache for storing all settings read with 'git config'"""
+
+    def __init__(self, files = [], parse_git = True, parse_local = True):
+        """Constructor for GitFatConfig objects. Arguments:
+               files: A list containing user-provided configuration files to load into the object's cache.
+               parse_git: When True the default Git configuration files will be loaded into the object's cache.
+               parse_local: When True, the .gitfat file at the root of the repo will be loaded into the object's cache."""
+        #self._data is a dict used for storing the all configuration settings
+        #The 'gitfat.runtime' key is used for house-keeping of parsed files
+        self._data = {'gitfat':{'runtime':{'parsed-files':[], 'parsed-git-config': False}}}
+        #The config formatter is used to allow for object notation when interpolating
+        self._config_formatter = ConfigFormatter()
+
+        last = len(files) - 1
+        for index, path in enumerate([path for path in files if path]):
+            #The last user-provided file is the main config file if .gitfat is not being parsed
+            is_main = not parse_local and index < last
+            self._cache_file(path=path, is_main=is_main)
+        if parse_git:
+            self._cache_file()
+        if parse_local:
+            try:
+                git_toplevel = sub.check_output('git rev-parse --show-toplevel'.split()).strip()
+            except sub.CalledProcessError:
+                raise RuntimeError('git-fat must be run from a git directory')
+            local_gitfat_config =  os.path.join(git_toplevel, '.gitfat')
+            if os.path.isfile(local_gitfat_config):
+                self._data['gitfat']['runtime']['localfile'] = local_gitfat_config
+                self._cache_file(path=local_gitfat_config, is_main=True)
+            else:
+               logger.warning( "Missing configfile at: {}".format(local_gitfat_config))
+
+    def get(self, key = None, interpolate = True):
+        """Returns the configuration value associated to dot-separated key"""
+        elem = self._data
+        if not isinstance(key, basestring):
+            raise TypeError("Expected {} but got {}".format(basestring, type(key)))
+        elif key is not None:
+            for field in key.split('.'):
+                if field in elem:
+                    elem = elem[field]
+                else:
+                    elem = None
+                    break
+        if interpolate:
+            result = self._interpolate(elem)
+        else:
+            result = elem
+        logger.debug("config.get({}) = {}".format(key, result))
+        return result
+
+    def _interpolate(self, elem):
+        """Recurses through dicts and performs interpolation of string values against self._data at 'get' time"""
+        if isinstance(elem, basestring):
+            visited = []
+            result = elem
+            while True:
+                try:
+                    next_result = self._config_formatter.vformat(result, visited, None, self._data)
+                except KeyError as err:
+                    raise RuntimeError("Could not interpolate '{}' with data from {}.".format(result, self._data['gitfat']['runtime']['parsed-files']))
+                except AttributeError as err:
+                    raise RuntimeError("Could not interpolate '{}' with data from {} due to '{}'.".format(result, self._data['gitfat']['runtime']['parsed-files'], err))
+                if result == next_result:
+                    break
+                else:
+                    result = next_result
+            return result
+        elif isinstance(elem, dict):
+            result = {}
+            for key, value in elem.iteritems():
+                result[key] = self._interpolate(value)
+            return result
+        else:
+            return elem
+
+    def set(self, key, value = None, update_gitconfig = False, cfgfile = None):
+        """Sets the configuration value associated to a dot-separated key"""
+        elem = self._data
+        if not isinstance(key, basestring):
+            raise TypeError("Expected {} but got {}".format(basestring, type(key)))
+        fields = key.split('.')
+        for field in fields[:-1]:
+            if field not in elem:
+                elem[field] = {}
+            elem = elem[field]
+        elem[fields[-1]] = value
+        if update_gitconfig:
+            gitargs = ['git', 'config']
+            if cfgfile is not None:
+                gitargs += ['--file', cfgfile]
+            gitargs += [key, value]
+            sub.check_call(gitargs)
+
+    def _cache_file(self, path=None, is_main=False):
+        """Uses 'git config --get-regexp .' to read a configuration file and store the
+            configuration data in the config dict. Arguments:
+                path: The target file, if None it will read Git's own configuration files.
+                is_main: Flags the main file (typically .gitfat) so that backwards compatibility is
+                         preserved when it comes to assuming that the default backend is the first section
+                         of the main file."""
+        is_first = True
+        if path:
+            self._data['gitfat']['runtime']['parsed-files'].append(path)
+        else:
+            self._data['gitfat']['runtime']['parsed-files'].append('<git-config-files>')
+            self._data['gitfat']['runtime']['parsed-git-config'] = True
+        gitargs = ['config']
+        if path is not None:
+            gitargs += ['--file', path]
+        gitargs += ['--get-regexp', '.']
+        p = git(gitargs, stdout=sub.PIPE)
+        stdout = p.communicate()[0].strip()
+        if p.returncode == 0:
+            for line in stdout.splitlines():
+                key_value_list = line.split(None,1)
+                if len(key_value_list) == 2:
+                    key, value = key_value_list
+                else:
+                    key = key_value_list[0]
+                    value = None
+                if is_main:
+                    fields = key.split('.', 1)
+                    #Defaults are only read from the main/last file and stored if they dont overwrite data
+                    if fields[0] == 'defaults' and self.get(fields[1], interpolate = False) is None:
+                        self.set(fields[1], value)
+                    else:
+                        self.set(key, value)
+                        if is_first:
+                            #The first non-defaults section is the default backend in legacy mode
+                            self._data['gitfat']['runtime']['firstsection'], option = os.path.splitext(key)
+                else:
+                    self.set(key, value)
+                #logger.debug('[config] {} = {}'.format(key, value))
+                is_first = False
+def _load_backend(config, kwargs):
     needs_backend = ('pull', 'push')
     backend_opt = kwargs.pop('backend', None)
-    config_file = kwargs.pop('config_file', None)
     backend = None
     if kwargs['func'] == 'pull':
         # since pull can be of the form pull [backend] [patterns], we need to check
@@ -1054,9 +1160,8 @@ def _load_backend(kwargs):
             kwargs['patterns'].insert(0, backend_opt)
             backend_opt = None
     if kwargs['func'] in needs_backend:
-        backend = _parse_config(backend=backend_opt, cfg_file_path=config_file)
+        backend = _get_backend(config, backend=backend_opt)
     return backend
-
 
 def main():
 
@@ -1076,8 +1181,12 @@ def main():
         '-d', "--debug", dest='debug', action='store_true',
         help='Get debugging output about what git-fat is doing')
     parser.add_argument(
-        '-c', "--config", dest='config_file', type=str,
-        help='Specify which config file to use (defaults to .gitfat)')
+        '-c', "--config", dest='config_file_list', type=str, action='append', default = [],
+        help="Specify which config files to use. Can be used multiple times. "\
+             "If not provided, git-fat will first load configuration data from the colon-searated "\
+             "files in $GIT_FAT_CONFIG (if GIT_FAT_CONFIG is defined), then it will parse the standard "\
+             "Git configuration files as in 'git config --get-regexp .' and finally it will parse the "\
+             "'.gitconfig' file at the root of the repository")
 
     # redundant function for legacy api; config gets called every time.
     # (assuming if user is calling git-fat they want it configured)
@@ -1135,19 +1244,35 @@ def main():
     args = parser.parse_args()
     kwargs = dict(vars(args))
 
+    #Popping both 'debug' and 'verbose' independently of each other in case
+    #both are passed on the invocation
+    log_level = _logging.WARNING
+    if kwargs.pop('verbose', None):
+        log_level = _logging.INFO
     if kwargs.pop('debug', None):
         log_level = _logging.DEBUG
-    elif kwargs.pop('verbose', None):
-        log_level = _logging.INFO
-    else:
-        log_level = _logging.WARNING
     _configure_logging(log_level)
 
+    if kwargs.pop('config_file_list', []):
+        #Config files where passed, hence to Git or .gitfat configs are read
+        config = GitFatConfig(files=args.config_file_list, parse_git=False, parse_local=False)
+    else:
+        #No config files where passed, hence $GIT_FAT_CONFIG, the Git files and .gitfat are read
+        config = GitFatConfig(os.getenv('GIT_FAT_CONFIG', '').split(':'), parse_git = True, parse_local=True)
+
+    require_backend = ('pull', 'push')
+
     try:
-        backend = _load_backend(kwargs)  # load_backend mutates kwargs
-        run(backend, **kwargs)
+        backend = _load_backend(config, kwargs)  # load_backend mutates kwargs
+        run(backend, config, **kwargs)
     except RuntimeError as err:
         logger.error(str(err))
+        try:
+            message = re.sub(r'\s+',' ', config.get('gitfat.canned-error-message'))
+        except:
+            pass
+        else:
+            print('\n' + message, file=sys.stderr)
         sys.exit(1)
     except:
         if kwargs.get('cur_file'):
@@ -1158,4 +1283,4 @@ def main():
 if __name__ == '__main__':
     main()
 
-__all__ = ['__version__', 'main', 'GitFat']
+__all__ = ['__version__', 'main', 'GitFat', 'GitFatConfig']

--- a/tests/pylint.cfg
+++ b/tests/pylint.cfg
@@ -52,7 +52,7 @@ bad-names=foo,bar,baz,toto,tutu,tata
 no-docstring-rgx=__.*__
 docstring-min-length=-1
 [IMPORTS]
-deprecated-modules=regsub,string,TERMIOS,Bastion,rexec
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
 import-graph=
 ext-import-graph=
 int-import-graph=
@@ -69,7 +69,7 @@ max-returns=4
 max-branches=12
 max-statements=50
 max-parents=7
-max-attributes=7
+max-attributes=8
 min-public-methods=0
 max-public-methods=20
 [EXCEPTIONS]

--- a/tests/test_git_fat.py
+++ b/tests/test_git_fat.py
@@ -10,10 +10,10 @@ import stat
 import platform
 import re
 
-#Import GitFatConfig for unit-testing it
+# Import GitFatConfig for unit-testing it
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 from git_fat.git_fat import GitFatConfig
-#Needed to undo the patching of suprocess.check_output in git_fat.py
+# Needed to undo the patching of suprocess.check_output in git_fat.py
 reload(sub)
 
 _logging.basicConfig(format='%(levelname)s:%(filename)s: %(message)s')
@@ -521,7 +521,9 @@ class GeneralTestCase(InitRepoTestCase):
 
         delete_file(filename)
 
+
 class ConfigTestCase(Base):
+
     def setUp(self):
         super(ConfigTestCase, self).setUp()
         with open('.gitfat', 'wb') as f:
@@ -548,7 +550,7 @@ class ConfigTestCase(Base):
         self.assertIsNone(config.get('section3.key1'))
 
     def test_cirular_ref(self):
-        files =  ['file1', 'file2', 'file3']
+        files = ['file1', 'file2', 'file3']
         with open(files[0], 'wb') as f:
             f.write('[section1]\nkey1={section2.key1}')
         with open(files[1], 'wb') as f:

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands =
     flake8
     pylint --rcfile=tests/pylint.cfg git_fat
     python -m unittest discover
+passenv = HOME
 
 [flake8]
 ignore=E201,E202,E128


### PR DESCRIPTION
ConfigParser is no longer used  and all parsing is done by 'git config'.
If no configuration file is passed as an argument, git-fat will parse
the following files:
1. Any colon-separated files in the environment variable $GIT_FAT_CONFIG, if any.
2. All Git configuration files as per 'git config' without the '--file' switch.
3. $(git rev-parse --show-toplevel)/.gitfat

git-fat will perform interpolation if needed to resolve git-fat related configuration
values.

This version works fine with legacy .gitffat files, but  introduces support for
the syntax below. See the README file for more details.

```
[gitfat]
    canned-error-message = "Please have a look at ..."
    [gitfat "rsync"]
            remote = {siteconfig.synchost}:{siteconfig.syncroot}
            user = git
            port = 2222
    [gitfat "http"]
            remote = {siteconfig.http-url}
    [defaults "gitfat"]
            backend = rsync
    [defaults "siteconfig"]
            synchost = localhost
            syncroot = /path/to/local/store/mount
            http-url = http://storage.example.com/store
```
